### PR TITLE
解决win系统中应用重启时frpc旧进程问题

### DIFF
--- a/electron/service/FrpcProcessService.ts
+++ b/electron/service/FrpcProcessService.ts
@@ -42,6 +42,25 @@ class FrpcProcessService {
               }
             }
           }
+        } else {
+          const processName = PathUtils.getWinFrpFilename();
+          const stdout = execSync(
+            `tasklist /FI "IMAGENAME eq ${processName}" /FO CSV`
+          ).toString();
+          const lines = stdout.split("\n").filter(Boolean);
+
+          if (lines.length > 1) {
+            const info = lines[1]
+              .split('","')
+              .map(s => s.replace(/(^"|"$)/g, ""));
+            const pid = parseInt(info[1], 10);
+            if (!Number.isNaN(pid)) {
+              this._frpcProcess = { pid };
+              if (this._frpcLastStartTime === -1) {
+                this._frpcLastStartTime = Date.now();
+              }
+            }
+          }
         }
       } catch (e) {
         // 忽略未找到进程的错误


### PR DESCRIPTION
部分情况（任务管理器终止frpc-Desktop进程）会导致frpc变成孤儿进程，启动前检查可方便解决问题