### PR TITLE
Add update notification setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@
 - [x] Support importing and recognizing frpc.toml
 - [x] TCP and UDP protocols support batch ports
 - [x] Support multiple languages
+- [x] Optional update notifications
 
 ## Common Issues
 

--- a/README.zh_CN.md
+++ b/README.zh_CN.md
@@ -48,6 +48,7 @@
 - [x] 支持导入识别frpc.toml
 - [x] tcp、udp协议支持批量端口
 - [x] support multiple languages
+- [x] 可选择是否推送更新通知
 
 
 ## 里程碑

--- a/docs/DATABASES.md
+++ b/docs/DATABASES.md
@@ -139,6 +139,7 @@ flowchart LR
 | `desktop` | `launch_at_startup` | `boolean` | `false` | `system.launchAtStartup` |
 | `desktop` | `silent_startup` | `boolean` | `false` | `system.silentStartup` |
 | `desktop` | `auto_connect_on_startup` | `boolean` | `false` | `system.autoConnectOnStartup` |
+| `desktop` | `notify_updates` | `boolean` | `true` | `system.notifyUpdates` |
 | `desktop` | `language` | `string` | `en-US` | `system.language` |
 
 这些默认记录的 `id` 由应用层生成 UUID。当前 `OpenSourceFrpcDesktopServer.system` 仍保留为 service 和 IPC 层的兼容结构。读取 server 配置时，由 service 查询 `desktop` 命名空间并组装成现有 `system` 对象；保存配置时，在同一事务内分别更新 server 和对应配置项。renderer 不需要感知这一拆分。

--- a/electron/controller/SystemController.ts
+++ b/electron/controller/SystemController.ts
@@ -5,14 +5,21 @@ import { BrowserWindow, dialog } from "electron";
 import BeanFactory from "../core/BeanFactory";
 import Logger from "../core/Logger";
 import GitHubService from "../service/GitHubService";
+import AppConfigRepository from "../repository/AppConfigRepository";
 
 class SystemController {
   private readonly _systemService: SystemService;
   private readonly _gitHubService: GitHubService;
+  private readonly _appConfigRepository: AppConfigRepository;
 
-  constructor() {
-    this._systemService = BeanFactory.getBean("systemService");
-    this._gitHubService = BeanFactory.getBean("gitHubService");
+  constructor(
+    systemService: SystemService,
+    gitHubService: GitHubService,
+    appConfigRepository: AppConfigRepository
+  ) {
+    this._systemService = systemService;
+    this._gitHubService = gitHubService;
+    this._appConfigRepository = appConfigRepository;
   }
 
   openUrl(req: ControllerParam) {
@@ -90,13 +97,26 @@ class SystemController {
   }
 
   getFrpcDesktopGithubLastRelease(req: ControllerParam) {
+    const manual = req.args.manual === true;
+    if (!manual && !this._appConfigRepository.getSystemConfig().notifyUpdates) {
+      req.event.reply(
+        req.channel,
+        ResponseUtils.success({
+          manual,
+          version: null,
+          skipped: true
+        })
+      );
+      return;
+    }
+
     this._gitHubService
       .getGithubLastRelease("luckjiawei/frpc-desktop")
       .then((data: any) => {
         req.event.reply(
           req.channel,
           ResponseUtils.success({
-            manual: req.args.manual,
+            manual,
             version: data
           })
         );

--- a/electron/database/NedbMigrationService.ts
+++ b/electron/database/NedbMigrationService.ts
@@ -337,6 +337,7 @@ class NedbMigrationService {
         launchAtStartup: false,
         silentStartup: false,
         autoConnectOnStartup: false,
+        notifyUpdates: true,
         language: "en-US"
       },
       user: ""
@@ -364,6 +365,11 @@ class NedbMigrationService {
         system.autoConnectOnStartup,
         false,
         "server.system.autoConnectOnStartup"
+      ),
+      notifyUpdates: this.boolean(
+        system.notifyUpdates,
+        true,
+        "server.system.notifyUpdates"
       ),
       language: this.string(system.language, "en-US")
     };

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -420,7 +420,14 @@ class FrpcDesktopApp {
         BeanFactory.getBean("proxyRepository")
       )
     );
-    BeanFactory.setBean("systemController", new SystemController());
+    BeanFactory.setBean(
+      "systemController",
+      new SystemController(
+        BeanFactory.getBean("systemService"),
+        BeanFactory.getBean("gitHubService"),
+        BeanFactory.getBean("appConfigRepository")
+      )
+    );
     Logger.info(`FrpcDesktopApp.initializeBeans`, `Beans initialized.`);
   }
 

--- a/electron/repository/AppConfigRepository.ts
+++ b/electron/repository/AppConfigRepository.ts
@@ -11,6 +11,7 @@ class AppConfigRepository {
     launchAtStartup: false,
     silentStartup: false,
     autoConnectOnStartup: false,
+    notifyUpdates: true,
     language: "en-US"
   };
 
@@ -41,6 +42,10 @@ class AppConfigRepository {
         values.get("auto_connect_on_startup"),
         AppConfigRepository.DESKTOP_DEFAULTS.autoConnectOnStartup
       ),
+      notifyUpdates: this.readBoolean(
+        values.get("notify_updates"),
+        AppConfigRepository.DESKTOP_DEFAULTS.notifyUpdates
+      ),
       language:
         values.get("language") || AppConfigRepository.DESKTOP_DEFAULTS.language
     };
@@ -65,6 +70,12 @@ class AppConfigRepository {
       "auto_connect_on_startup",
       "boolean",
       String(config.autoConnectOnStartup ?? false)
+    );
+    this.upsert(
+      "desktop",
+      "notify_updates",
+      "boolean",
+      String(config.notifyUpdates ?? true)
     );
     this.upsert("desktop", "language", "string", config.language || "en-US");
   }

--- a/electron/service/ServerService.ts
+++ b/electron/service/ServerService.ts
@@ -307,6 +307,7 @@ ${f}`;
             launchAtStartup: false,
             silentStartup: false,
             autoConnectOnStartup: false,
+            notifyUpdates: true,
             language: "en-US"
           },
           user: ""
@@ -832,6 +833,7 @@ ${f}`;
           launchAtStartup: false,
           silentStartup: false,
           autoConnectOnStartup: false,
+          notifyUpdates: true,
           language: language
         },
         user: ""

--- a/src/lang/en-US.ts
+++ b/src/lang/en-US.ts
@@ -219,6 +219,11 @@ export default {
         requireMessage: "Please select whether to enable auto connect",
         tips: "Auto connect to the server when the system starts"
       },
+      systemNotifyUpdates: {
+        label: "Update Notifications",
+        requireMessage: "Please select whether to enable update notifications",
+        tips: "Notify you automatically when a new version is available. You can still check manually on the About page when disabled."
+      },
       transportHeartbeatInterval: {
         label: "Heartbeat Interval",
         requireMessage: "Please enter heartbeat interval",

--- a/src/lang/zh-CN.ts
+++ b/src/lang/zh-CN.ts
@@ -218,6 +218,11 @@ export default {
         requireMessage: "请选择是否开启自动连接",
         tips: " 开启后启动时<span class='font-black text-[#5A3DAA]'>自动连接</span>"
       },
+      systemNotifyUpdates: {
+        label: "更新推送",
+        requireMessage: "请选择是否推送更新",
+        tips: "有新版本时自动推送更新通知；关闭后仍可在关于页面手动检查更新"
+      },
       transportHeartbeatInterval: {
         label: "心跳间隔时间",
         requireMessage: "心跳间隔时间不能为空",

--- a/src/store/frpcDesktop.ts
+++ b/src/store/frpcDesktop.ts
@@ -56,7 +56,10 @@ export const useFrpcDesktopStore = defineStore("frpcDesktop", {
     },
     onListenerFrpcDesktopGithubLastRelease(sd?: false) {
       on(ipcRouters.SYSTEM.getFrpcDesktopGithubLastRelease, data => {
-        const { manual, version } = data;
+        const { manual, version, skipped } = data;
+        if (skipped || !version) {
+          return;
+        }
         this.lastRelease = version;
         // tagName相对固定
         const tagName = this.lastRelease["tag_name"];

--- a/src/views/config/index.vue
+++ b/src/views/config/index.vue
@@ -88,6 +88,7 @@ const defaultFormData: OpenSourceFrpcDesktopServer = {
     launchAtStartup: false,
     silentStartup: false,
     autoConnectOnStartup: false,
+    notifyUpdates: true,
     language: "en-US"
   },
   user: ""
@@ -222,6 +223,13 @@ const rules = reactive<FormRules>({
     {
       required: true,
       message: t("config.form.systemAutoConnectOnStartup.requireMessage"),
+      trigger: "change"
+    }
+  ],
+  "system.notifyUpdates": [
+    {
+      required: true,
+      message: t("config.form.systemNotifyUpdates.requireMessage"),
       trigger: "change"
     }
   ],
@@ -1668,6 +1676,38 @@ onUnmounted(() => {
                 </template>
                 <el-switch
                   v-model="formData.system.autoConnectOnStartup"
+                  :active-text="t('common.yes')"
+                  :inactive-text="t('common.no')"
+                  inline-prompt
+                />
+              </el-form-item>
+            </el-col>
+            <el-col :span="8">
+              <el-form-item
+                :label="t('config.form.systemNotifyUpdates.label')"
+                prop="system.notifyUpdates"
+              >
+                <template #label>
+                  <div class="flex items-center mr-1 h-full">
+                    <el-popover placement="top" width="300" trigger="hover">
+                      <template #default>
+                        <div
+                          v-html="t('config.form.systemNotifyUpdates.tips')"
+                        ></div>
+                      </template>
+                      <template #reference>
+                        <IconifyIconOffline
+                          class="text-base"
+                          color="#5A3DAA"
+                          icon="info"
+                        />
+                      </template>
+                    </el-popover>
+                  </div>
+                  {{ t("config.form.systemNotifyUpdates.label") }}
+                </template>
+                <el-switch
+                  v-model="formData.system.notifyUpdates"
                   :active-text="t('common.yes')"
                   :inactive-text="t('common.no')"
                   inline-prompt

--- a/types/frpc-desktop.d.ts
+++ b/types/frpc-desktop.d.ts
@@ -8,6 +8,7 @@ interface FrpcSystemConfiguration {
   launchAtStartup: boolean;
   silentStartup: boolean;
   autoConnectOnStartup: boolean;
+  notifyUpdates: boolean;
   language: string;
 }
 


### PR DESCRIPTION
## What changed

- add an Update Notifications switch to Settings with Chinese and English copy
- persist the preference in the desktop application config with a backward-compatible default of enabled
- skip automatic update checks when disabled while preserving manual checks from About
- document the new application configuration key

## Impact

Users can opt out of startup update prompts without losing the ability to check for updates manually.

## Validation

- changed-file ESLint: 0 errors (existing warnings only)
- Vite production build: passed for renderer, Electron main, and preload
- Windows x64 NSIS installer: built successfully
- packaged application smoke test: stayed running and initialized SQLite successfully
- `git diff --check`: passed

## Known repository issues

Full `vue-tsc --noEmit` remains blocked by pre-existing Element Plus `DefaultRow` typing errors in the download and proxy views. Full lint also reports the repository's existing CRLF/Prettier mismatch.

## Summary by Sourcery

Add a configurable setting to control automatic update notifications while keeping manual update checks available.

New Features:
- Introduce a notifyUpdates system configuration flag surfaced as a toggle in the Settings UI with English and Chinese copy.
- Allow users to disable automatic update checks at startup without affecting manual checks from the About page.

Enhancements:
- Wire the system controller to the app configuration repository so update checks respect the stored preference.
- Extend the IPC listener and store logic to ignore skipped or empty update responses.

Documentation:
- Document the new notify_updates desktop configuration key in the database documentation and list optional update notifications in both README files.